### PR TITLE
Fix SSID retrevial fails for systems with non-english locales

### DIFF
--- a/wifi-qr.sh
+++ b/wifi-qr.sh
@@ -27,7 +27,7 @@ function linux {
     fi
   else
     # get current ssid
-    ssid="`nmcli -t -f active,ssid dev wifi | egrep '^yes' | cut -d\: -f2`"
+    ssid="`nmcli -t -f in-use,ssid dev wifi | egrep '^\*' | cut -d\: -f2`"
     if [ "$ssid" = "" ]; then
       echo "ERROR: Could not retrieve current SSID. Are you connected?" >&2
       exit 1


### PR DESCRIPTION
Line 30 greps for a line starting with "yes" (the "active" field) but, in e.g. a French system, these fields will have "oui" and "non" instead of "yes" and "no".

Use the "in-use" field, which outputs an asterisk `*` for the in-use network and a space otherwise. grep for a line starting with "*".